### PR TITLE
Re-add Privex Payment Gateway

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1062,6 +1062,15 @@
       "url":"https://dappspinach.io",
       "hasimage":"1",
       "subdomains":["*"]
+    },
+    {
+      "applink": "pay.privex.io",
+      "name": "Privex Payment Gateway",
+      "type": "Payment",
+      "description": "Privex - Private, fast, and low cost servers for cryptocurrency",
+      "url": "https://privex.io",
+      "hasimage": "1",
+      "subdomains":["*"]
     }
   ],
   "Ethereum": [


### PR DESCRIPTION
Re-added Privex Payment Gateway (pay.privex.io).

Our SVG is still present in the logos folder.